### PR TITLE
Fixes to env.sample file

### DIFF
--- a/GraphAgent/env.sample
+++ b/GraphAgent/env.sample
@@ -1,5 +1,5 @@
 GOOGLE_GENAI_USE_VERTEXAI=1
-GOOGLE_CLOUD_PROJECT=myproject
+GOOGLE_CLOUD_PROJECT=myproject #can you address this fix, needs to be user's project
 GOOGLE_CLOUD_LOCATION=us-west1
-GCP_SPANNER_DATABASE=spannerdb
-GCP_SPANNER_INSTANCE=myinstance
+GCP_SPANNER_DATABASE=useridentitydb
+GCP_SPANNER_INSTANCE=useridentity

--- a/GraphAgent/tools.yaml
+++ b/GraphAgent/tools.yaml
@@ -3,7 +3,7 @@ sources:
     database: useridentitydb
     instance: useridentity
     kind: spanner
-    project: mague-tf
+    project: ${GOOGLE_CLOUD_PROJECT}
 
 tools:
   lookup_account_by_email:


### PR DESCRIPTION
- Changed the env.sample files so that the GCP_SPANNER_DATABASE & GCP_SPANNER_INSTANCE variables are consistent with the rest of the code. 
- Changed the tools.yaml file so the source definition pulls the project value from the environment variable

Need: the user needs to set the project name environment variable or we can assume that the adc will automatically fill it